### PR TITLE
Simply listing of all IMF dataflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "requests",
     "pandas",
-    "lxml",
-	"sdmx1",
-	"msal"
+	  "sdmx1",
+	  "msal",
 ]
 
 [tool.setuptools]

--- a/src/imfidata/auth.py
+++ b/src/imfidata/auth.py
@@ -60,7 +60,7 @@ def acquire_access_token(scopes: List[str] = SCOPES) -> Dict[str, str]:
     return result
 
 
-def auth_header(needs_auth: bool = True) -> Dict[str, str]:
+def get_request_header(needs_auth: bool = True) -> Dict[str, str]:
     """
     Return a standard header with optional Authorization.
     """

--- a/src/imfidata/metadata.py
+++ b/src/imfidata/metadata.py
@@ -16,7 +16,7 @@ from .utils import make_env_from_pairs
 def show_imf_datasets(needs_auth: bool = False) -> pd.DataFrame:
     """
     Fetches the IMF SDMX Dataflow registry and returns a DataFrame:
-    columns: id, version, agencyID, name
+    columns: id, version, agencyID, name_en
     """
     client = get_client()
     headers = get_request_header(needs_auth)

--- a/src/imfidata/metadata.py
+++ b/src/imfidata/metadata.py
@@ -7,7 +7,7 @@ import pandas as pd
 import sdmx
 from sdmx import Resource
 
-from . import auth
+from .auth import get_request_header
 from .sdmx_client import get_client
 from .utils import make_env_from_pairs
 
@@ -19,8 +19,9 @@ def show_imf_datasets(needs_auth: bool = False) -> pd.DataFrame:
     columns: id, version, agencyID, name
     """
     client = get_client()
+    headers = get_request_header(needs_auth)
     rows = []
-    for dataset in client.dataflow().iter_objects():
+    for dataset in client.dataflow(headers=headers).iter_objects():
         if isinstance(dataset, sdmx.model.v21.DataflowDefinition):
             rows.append(
             {

--- a/src/imfidata/retrieval.py
+++ b/src/imfidata/retrieval.py
@@ -1,17 +1,10 @@
-
-
 # retrieval.py
 from __future__ import annotations
-from typing import Optional, Dict
 import pandas as pd
 import sdmx
 
 from .sdmx_client import get_client
-from . import auth
-from . import utils
-
-import os
-import tempfile
+from .auth import get_request_header
 
 
 def convert_time_period_auto(df, time_col='TIME_PERIOD', out_col='date'):
@@ -88,15 +81,9 @@ def imfdata_by_key(
     Returns:
       pandas.DataFrame of the time series.
     """
-    headers = {"User-Agent": "idata-script-client"}
+    client = get_client()
+    headers = get_request_header(needs_auth)
 
-    if needs_auth:
-        token_resp = auth.acquire_access_token()
-        token_type = token_resp.get("token_type", "Bearer")
-        access_token = token_resp["access_token"]
-        headers["Authorization"] = f"{token_type} {access_token}"
-
-    client = sdmx.Client('IMF_DATA')
     try:
         msg = client.data(
             resource_id=dataset,


### PR DESCRIPTION
Use SDMX1 functionality to list all dataflows, removing direct dependency on requests and lxml.
Simply how other files interact with auth. (not a review of auth file itself)
